### PR TITLE
Feature/295 update ac tool hook documentation

### DIFF
--- a/docs/ApplyConfig.md
+++ b/docs/ApplyConfig.md
@@ -15,7 +15,7 @@ The following section explain how you can trigger the installation of ACLs.
 ## Installation Hook
 
 You can automatically install ACEs and authorizables defined in YAML files within a package using the Content Package Install Hook mechanism.
-If you use the content-package-maven-plugin (before the 1.0.2 release) enable the installation hook via: 
+If you use the content-package-maven-plugin for building the package, enable the installation hook via: 
 
 ```
 <plugin>
@@ -29,7 +29,7 @@ If you use the content-package-maven-plugin (before the 1.0.2 release) enable th
 </plugin>
 ```
 
-If you use version 1.0.2 or later of the content-package-maven-plugin then the installation hook will have to be configured using the jackrabbit filevault-package-maven-plugin:
+If you would rather use the filevault-package-maven-plugin for building the package, enable the installation hook via:
 
 ```
 <plugin>

--- a/docs/ApplyConfig.md
+++ b/docs/ApplyConfig.md
@@ -15,7 +15,7 @@ The following section explain how you can trigger the installation of ACLs.
 ## Installation Hook
 
 You can automatically install ACEs and authorizables defined in YAML files within a package using the Content Package Install Hook mechanism.
-If you use the content-package-maven-plugin (before the 1.02 release) enable the installation hook via: 
+If you use the content-package-maven-plugin (before the 1.0.2 release) enable the installation hook via: 
 
 ```
 <plugin>
@@ -29,7 +29,7 @@ If you use the content-package-maven-plugin (before the 1.02 release) enable the
 </plugin>
 ```
 
-If you use version 1.02 or later of the content-package-maven-plugin then the installation hook will have to be configured using the jackrabbit filevault-package-maven-plugin:
+If you use version 1.0.2 or later of the content-package-maven-plugin then the installation hook will have to be configured using the jackrabbit filevault-package-maven-plugin:
 
 ```
 <plugin>

--- a/docs/ApplyConfig.md
+++ b/docs/ApplyConfig.md
@@ -15,7 +15,7 @@ The following section explain how you can trigger the installation of ACLs.
 ## Installation Hook
 
 You can automatically install ACEs and authorizables defined in YAML files within a package using the Content Package Install Hook mechanism.
-If you use the content-package-maven-plugin enable the installation hook via: 
+If you use the content-package-maven-plugin (before the 1.02 release) enable the installation hook via: 
 
 ```
 <plugin>
@@ -26,6 +26,20 @@ If you use the content-package-maven-plugin enable the installation hook via:
       <installhook.actool.class>biz.netcentric.cq.tools.actool.installhook.AcToolInstallHook</installhook.actool.class>
     </properties>
   </configuration>
+</plugin>
+```
+
+If you use version 1.02 or later of the content-package-maven-plugin then the installation hook will have to be configured using the jackrabbit filevault-package-maven-plugin:
+
+```
+<plugin>
+    <groupId>org.apache.jackrabbit</groupId>
+    <artifactId>filevault-package-maven-plugin</artifactId>
+    <configuration>
+        <properties>
+            <installhook.actool.class>biz.netcentric.cq.tools.actool.installhook.AcToolInstallHook</installhook.actool.class>
+        </properties>
+    </configuration>
 </plugin>
 ```
 


### PR DESCRIPTION
Update documentation for projects with the content-package-maven-plugin on versions equals or higher than 1.0.2